### PR TITLE
extract variable name instead of just using data

### DIFF
--- a/src/transformers.rs
+++ b/src/transformers.rs
@@ -7,7 +7,7 @@ fn to_test_fn(content_tokens: TokenStream, input_identifier: TokenStream) -> Str
     let test_fn = quote! {
         #[test]
         fn test_something() {
-            let #input_identifier = [];
+            let #input_identifier = []; #[doc="This is a test template"]
             #content_tokens
         }
     };

--- a/src/transformers.rs
+++ b/src/transformers.rs
@@ -15,15 +15,21 @@ fn to_test_fn(content_tokens: TokenStream, input_identifier: TokenStream) -> Str
     return test_fn.to_string();
 }
 
+/// Extract the input identifier from the input tokens,
+/// get the first variable name before the type (starting with ':')
+///
+/// e.g. input_identifier_wo_type("a: &u8") -> "a"
 fn input_identifier_wo_type(inputs: TokenStream) -> TokenStream {
-    let mut input_identifier = TokenStream::new();
-    for token in inputs.into_iter() {
-        match &token {
-            TokenTree::Punct(punct) if punct.as_char() == ':' => break,
-            _ => input_identifier.extend(Some(token)),
-        }
-    }
-    input_identifier
+    inputs
+        .into_iter()
+        .take_while(|token| {
+            if let TokenTree::Punct(punct) = token {
+                punct.as_char() != ':'
+            } else {
+                true
+            }
+        })
+        .collect()
 }
 /// add println!() to the beginning of the fuzz_target! macro
 pub struct ReportTransformer {


### PR DESCRIPTION
Tested on https://github.com/astral-sh/ruff

```rust
fn do_fuzz(case: &[u8]) -> Corpus {
    let Ok(code) = std::str::from_utf8(case) else {
        return Corpus::Reject;
    };
    let settings = SETTINGS.get_or_init(LinterSettings::default);
    ruff_linter::test::set_max_iterations(usize::MAX);
    let _ = ruff_linter::test::test_snippet(code, settings);
    Corpus::Keep
}
fuzz_target!(|case: &[u8]| {
    println!("{:?}", case);
    do_fuzz(case)
});
```

```rust
#[test]
fn test_something() {
    let case = [];
    do_fuzz(case)
}
```